### PR TITLE
feat: add support to configure proxy read timeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Caching proxy docker image
+
 [![Docker Pulls](https://img.shields.io/docker/pulls/decentralize/caching-proxy.svg)](https://hub.docker.com/r/decentralize/caching-proxy)
 [![Build Status](https://ci.strahlungsfrei.de/api/badges/djmaze/docker-caching-proxy/status.svg)](https://ci.strahlungsfrei.de/djmaze/docker-caching-proxy)
 
@@ -16,6 +17,7 @@ The container needs two environment variables:
 * `ALLOWED_ORIGIN`: origin URL which is allowed to load the files from this server (header `Access-Control-Allowed-Origins`) (default `*`)
 * `MAX_SIZE`: Size of the cache to use (on-disk)
 * `GZIP`: Set to `off` in order to disable gzip compression (enabled by default)
+* `PROXY_READ_TIMEOUT`: Set the timeout for reading a response from the proxied server (default: 120s)
 
 The server will be listening on port 80.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,7 @@ sed -i "s|\$MAX_SIZE|${MAX_SIZE:-10g}|" /etc/nginx/nginx.conf
 sed -i "s|\$UPSTREAM|${UPSTREAM}|" /etc/nginx/nginx.conf
 sed -i "s|\$GZIP|${GZIP:-on}|" /etc/nginx/nginx.conf
 sed -i "s|\$ALLOWED_ORIGIN|${ALLOWED_ORIGIN:-*}|" /etc/nginx/nginx.conf
+sed -i "s|\$PROXY_READ_TIMEOUT|${PROXY_READ_TIMEOUT:-120s}|" /etc/nginx/nginx.conf
+
 
 exec "$@"

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,6 +38,7 @@ http {
             set $backend $UPSTREAM;
             proxy_pass $backend;
             proxy_cache my_cache;
+            proxy_read_timeout $PROXY_READ_TIMEOUT;
 
             add_header 'Access-Control-Allow-Origin' '$ALLOWED_ORIGIN';
         }


### PR DESCRIPTION
First of all thanks for this nice project. I wanted to implement this on my own but found yours and decided to use it.

Bit of background why proxy read timeout is needed on my side:

I am using this Prometheus exporter (https://github.com/peimanja/artifactory_exporter) which takes quite long to fetch all the data from the service. The default read timeout of 60s in nginx is not enough and therefore the changes in this PR.
