### PR TITLE
feat: add support for controlling validity of the proxy cache.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The container needs two environment variables:
 * `MAX_SIZE`: Size of the cache to use (on-disk)
 * `GZIP`: Set to `off` in order to disable gzip compression (enabled by default)
 * `PROXY_READ_TIMEOUT`: Set the timeout for reading a response from the proxied server (default: 120s)
+* `PROXY_CACHE_VALID`: Set caching time for 200, 301, and 302 responses (disabled by default)
 
 The server will be listening on port 80.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,5 +7,9 @@ sed -i "s|\$GZIP|${GZIP:-on}|" /etc/nginx/nginx.conf
 sed -i "s|\$ALLOWED_ORIGIN|${ALLOWED_ORIGIN:-*}|" /etc/nginx/nginx.conf
 sed -i "s|\$PROXY_READ_TIMEOUT|${PROXY_READ_TIMEOUT:-120s}|" /etc/nginx/nginx.conf
 
+if [[ "${PROXY_CACHE_VALID+x}" ]]; then
+  PROXY_CACHE_VALID="proxy_cache_valid ${PROXY_CACHE_VALID};"
+fi
+sed -i "s|\$PROXY_CACHE_VALID|${PROXY_CACHE_VALID-}|" /etc/nginx/nginx.conf
 
 exec "$@"

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,6 +39,7 @@ http {
             proxy_pass $backend;
             proxy_cache my_cache;
             proxy_read_timeout $PROXY_READ_TIMEOUT;
+            $PROXY_CACHE_VALID
 
             add_header 'Access-Control-Allow-Origin' '$ALLOWED_ORIGIN';
         }


### PR DESCRIPTION
Once https://github.com/djmaze/docker-caching-proxy/pull/4 is merged I would rebase this branch.