### PR TITLE
Use nameserver provided by docker

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,4 +12,7 @@ if [[ "${PROXY_CACHE_VALID+x}" ]]; then
 fi
 sed -i "s|\$PROXY_CACHE_VALID|${PROXY_CACHE_VALID-}|" /etc/nginx/nginx.conf
 
+export NAMESERVER=`cat /etc/resolv.conf | grep "nameserver" | awk '{print $2}' | tr '\n' ' '`
+sed -i "s|\$NAMESERVER|${NAMESERVER}|" /etc/nginx/nginx.conf
+
 exec "$@"

--- a/nginx.conf
+++ b/nginx.conf
@@ -34,7 +34,7 @@ http {
 
     server {
         location / {
-            resolver 127.0.0.11 valid=10s;
+            resolver $NAMESERVER valid=10s;
             set $backend $UPSTREAM;
             proxy_pass $backend;
             proxy_cache my_cache;


### PR DESCRIPTION
Attempting to use this container leads to a DNS resolution error:

```
2022/10/04 14:22:42 [error] 11#11: send() failed (111: Connection refused) while resolving, resolver: 127.0.0.11:53
```

DNS server address is hardcoded in https://github.com/djmaze/docker-caching-proxy/blob/1a1663d89f8a73b6f13c6d1cced94990b194aee5/nginx.conf#L37 and my DNS is located at a different address.

NGINX doesn't seem to support using system resolver because it blocks and it can't parse /etc/resolv.conf (booo).

This PR will "parse" the docker-generated /etc/resolv.conf and substitute it into the config ([found the idea on serverfault](https://serverfault.com/questions/638822/nginx-resolver-address-from-etc-resolv-conf/821625#821625))
